### PR TITLE
Improve order dialog and notifications

### DIFF
--- a/src/app/views/dashboard-mecanica/OrdenTrabajoMecanico/agregar-orden-trabajo-mecanico/agregar-orden-trabajo-mecanico.component.scss
+++ b/src/app/views/dashboard-mecanica/OrdenTrabajoMecanico/agregar-orden-trabajo-mecanico/agregar-orden-trabajo-mecanico.component.scss
@@ -2,10 +2,10 @@
 .header-container {
     display: flex;
     align-items: center;
-    background-color: #f0f2f5;
+    background-color: #ffffff;
     padding: 0.8rem 1.5rem;
-    border-radius: 0.5rem;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid #e5e7eb;
+    box-shadow: none;
     margin-bottom: 1rem;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   }
@@ -36,26 +36,26 @@
 /* blocks.component.css - Estilos para bloques que siguen el mismo estilo del header */
 
 /* Contenedor principal del bloque */
-.block-container {
+  .block-container {
     border: 1px solid #e1e4e8;
     border-radius: 0.5rem;
-    background-color: #f0f2f5;
+    background-color: #ffffff;
     color: #333;
     margin-bottom: 1rem;
     overflow: hidden;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: none;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   }
   
   /* Título del bloque */
   .block-title {
-    background-color: #1f295b;
-    color: #fff;
-    text-align: center;
-    padding: 0.8rem 0;
+    background-color: transparent;
+    color: #1f2937;
+    text-align: left;
+    padding: 0.8rem 1rem;
     margin: 0;
     font-size: 1.1rem;
-    font-weight: 500;
+    font-weight: 600;
     border-bottom: 1px solid #e1e4e8;
   }
   

--- a/src/app/views/dashboard-mecanica/OrdenTrabajoMecanico/agregar-orden-trabajo-mecanico/agregar-orden-trabajo-mecanico.component.ts
+++ b/src/app/views/dashboard-mecanica/OrdenTrabajoMecanico/agregar-orden-trabajo-mecanico/agregar-orden-trabajo-mecanico.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ClienteService } from '../../../services/cliente.service';
@@ -157,6 +157,18 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
   mensajeError: any;
   mensajeExito: any;
 
+  // Configuración general de los mensajes Toastr
+  toastOptions = {
+    timeOut: 3000,
+    positionClass: 'toast-bottom-right',
+    progressBar: true,
+    closeButton: true
+  };
+
+  // Referencias a los componentes de registro
+  @ViewChild('registroCliente') registroCliente!: RegistroClienteComponent;
+  @ViewChild('registroVehiculo') registroVehiculo!: RegistroVehiculoComponent;
+
   constructor(
     private router: Router,
     private validacionService: ValidacionService,
@@ -192,13 +204,13 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
           if (this.ordenData.idUsuario === 158) {
           }
         } else {
-          this.toastr.error('Error al obtener información del usuario', 'Error de autenticación');
+          this.toastr.error('Error al obtener información del usuario', 'Error de autenticación', this.toastOptions);
         }
       } else {
-        this.toastr.error('Error al obtener información del usuario', 'Error de autenticación');
+        this.toastr.error('Error al obtener información del usuario', 'Error de autenticación', this.toastOptions);
       }
     } catch (error) {
-      this.toastr.error('Error al obtener información del usuario', 'Error de autenticación');
+      this.toastr.error('Error al obtener información del usuario', 'Error de autenticación', this.toastOptions);
     }
   }
   cargarSupervisores() {
@@ -209,13 +221,13 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
         this.cargandoMecanicos = false;
 
         if (this.mecanicos.length === 0) {
-          this.toastr.warning('No se encontraron mecánicos disponibles', 'Advertencia');
+          this.toastr.warning('No se encontraron mecánicos disponibles', 'Advertencia', this.toastOptions);
         }
       },
       error: (error) => {
         console.error('Error al cargar mecánicos:', error);
         this.cargandoMecanicos = false;
-        this.toastr.error('No se pudieron cargar los mecánicos', 'Error');
+        this.toastr.error('No se pudieron cargar los mecánicos', 'Error', this.toastOptions);
         this.mecanicos = [
           { idMecanico: 0, nombre: 'No se pudieron cargar mecánicos' }
         ];
@@ -243,7 +255,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
 
   validarCliente() {
     if (!this.documento || this.documento.trim() === '') {
-      this.toastr.warning('Por favor ingrese un documento válido', 'Advertencia');
+      this.toastr.warning('Por favor ingrese un documento válido', 'Advertencia', this.toastOptions);
       return;
     }
     this.cargandoCliente = true;
@@ -259,18 +271,18 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
           this.ordenData.idCliente = this.clienteActual.idPersona;
 
           if (this.clienteActual.esClienteActivo) {
-            this.toastr.success('Cliente encontrado', 'Éxito');
+            this.toastr.success('Cliente encontrado', 'Éxito', this.toastOptions);
           } else {
-            this.toastr.info('El cliente existe pero no está activo', 'Información');
+            this.toastr.info('El cliente existe pero no está activo', 'Información', this.toastOptions);
           }
         },
         error: (error: any) => {
           console.error('Error al validar el cliente:', error);
           this.cargandoCliente = false;
           if (error.status === 404) {
-            this.toastr.warning('Cliente no encontrado', 'No existe');
+            this.toastr.warning('Cliente no encontrado', 'No existe', this.toastOptions);
           } else {
-            this.toastr.error('Error al validar el cliente', 'Error');
+            this.toastr.error('Error al validar el cliente', 'Error', this.toastOptions);
           }
         }
       });
@@ -278,7 +290,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
 
   validarVehiculo() {
     if (!this.placa || this.placa.trim() === '') {
-      this.toastr.warning('Por favor ingrese una placa válida', 'Advertencia');
+      this.toastr.warning('Por favor ingrese una placa válida', 'Advertencia', this.toastOptions);
       return;
     }
 
@@ -305,11 +317,11 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
           this.cargandoVehiculo = false;
 
           if (this.vehiculoActual.estado === 0) {
-            this.toastr.success('Vehículo encontrado - Estado: Operativo', 'Éxito');
+            this.toastr.success('Vehículo encontrado - Estado: Operativo', 'Éxito', this.toastOptions);
           } else if (this.vehiculoActual.estado === 1) {
-            this.toastr.info('Vehículo encontrado - Estado: En Mantenimiento', 'Información');
+            this.toastr.info('Vehículo encontrado - Estado: En Mantenimiento', 'Información', this.toastOptions);
           } else if (this.vehiculoActual.estado === 2) {
-            this.toastr.warning('Vehículo encontrado - Estado: De Baja', 'Precaución');
+            this.toastr.warning('Vehículo encontrado - Estado: De Baja', 'Precaución', this.toastOptions);
           }
         },
         error: (error) => {
@@ -317,9 +329,9 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
           this.cargandoVehiculo = false;
 
           if (error.status === 404) {
-            this.toastr.warning('Vehículo no encontrado', 'No existe');
+            this.toastr.warning('Vehículo no encontrado', 'No existe', this.toastOptions);
           } else {
-            this.toastr.error('Error al validar el vehículo', 'Error');
+            this.toastr.error('Error al validar el vehículo', 'Error', this.toastOptions);
           }
         }
       });
@@ -329,23 +341,23 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
   }
   validarDatosOrden(): boolean {
     if (!this.clienteActual || !this.vehiculoActual) {
-      this.toastr.warning('Debe seleccionar un cliente y un vehículo antes de crear la orden', 'Datos incompletos');
+      this.toastr.warning('Debe seleccionar un cliente y un vehículo antes de crear la orden', 'Datos incompletos', this.toastOptions);
       return false;
     }
     if (!this.ordenData.idMecanico) {
-      this.toastr.warning('Debe seleccionar un mecánico', 'Datos incompletos');
+      this.toastr.warning('Debe seleccionar un mecánico', 'Datos incompletos', this.toastOptions);
       return false;
     }
     if (!this.ordenData.detalle || this.ordenData.detalle.trim() === '') {
-      this.toastr.warning('Debe ingresar una descripción del mantenimiento', 'Datos incompletos');
+      this.toastr.warning('Debe ingresar una descripción del mantenimiento', 'Datos incompletos', this.toastOptions);
       return false;
     }
     if (!this.ordenData.kilometraje || this.ordenData.kilometraje <= 0) {
-      this.toastr.warning('Debe ingresar un kilometraje válido', 'Datos incompletos');
+      this.toastr.warning('Debe ingresar un kilometraje válido', 'Datos incompletos', this.toastOptions);
       return false;
     }
     if (!this.ordenData.fechaProgramada) {
-      this.toastr.warning('Debe seleccionar una fecha programada', 'Datos incompletos');
+      this.toastr.warning('Debe seleccionar una fecha programada', 'Datos incompletos', this.toastOptions);
       return false;
     }
     return true;
@@ -356,7 +368,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
     // ✅ Verificación mejorada con más detalles
     if (!this.ordenData.idUsuario || this.ordenData.idUsuario === 0) {
       console.error('❌ idUsuario no válido:', this.ordenData.idUsuario);
-      this.toastr.error('No se pudo obtener la información del usuario. Por favor, inicie sesión nuevamente.', 'Error de autenticación');
+      this.toastr.error('No se pudo obtener la información del usuario. Por favor, inicie sesión nuevamente.', 'Error de autenticación', this.toastOptions);
       return;
     }
 
@@ -376,7 +388,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
 
         try {
           const response = await firstValueFrom(this.ordenTrabajoService.agendarOrdenMecanico(this.ordenData));
-          this.toastr.success('Orden de trabajo creada exitosamente', 'Éxito');
+          this.toastr.success('Orden de trabajo creada exitosamente', 'Éxito', this.toastOptions);
 
           if (this.hayImagenesParaSubir()) {
             await this.subirImagenes();
@@ -385,11 +397,11 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
           this.creandoOrden = false;
           this.router.navigate([`/mecanica/${response.codigo}`]);
         } catch (error) {
-          this.toastr.error('No se pudo crear la orden de trabajo', 'Error');
+          this.toastr.error('No se pudo crear la orden de trabajo', 'Error', this.toastOptions);
           this.creandoOrden = false;
         }
       } else {
-        this.toastr.error('Código incorrecto o cancelado', 'Error');
+        this.toastr.error('Código incorrecto o cancelado', 'Error', this.toastOptions);
       }
     });
   }
@@ -466,7 +478,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
               this.procesarArchivo(archivoComprimido, tipo);
 
               // Mostrar mensaje de que se comprimió la imagen
-              this.toastr.info('La imagen ha sido comprimida para mejorar el rendimiento', 'Imagen optimizada');
+              this.toastr.info('La imagen ha sido comprimida para mejorar el rendimiento', 'Imagen optimizada', this.toastOptions);
             }
           }, 'image/jpeg', 0.85);
         }
@@ -477,13 +489,13 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
   }
   procesarArchivo(file: File, tipo: string): void {
     if (!file.type.startsWith('image/')) {
-      this.toastr.warning('Solo se permiten archivos de imagen (JPG, PNG, etc.)', 'Formato no válido');
+      this.toastr.warning('Solo se permiten archivos de imagen (JPG, PNG, etc.)', 'Formato no válido', this.toastOptions);
       return;
     }
 
     const maxSizeInBytes = 5 * 1024 * 1024; // 5MB
     if (file.size > maxSizeInBytes) {
-      this.toastr.warning('La imagen debe ser menor a 5MB', 'Archivo muy grande');
+      this.toastr.warning('La imagen debe ser menor a 5MB', 'Archivo muy grande', this.toastOptions);
       return;
     }
 
@@ -557,14 +569,14 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
         acceptLabel: 'Sí, eliminar imagen',
         rejectLabel: 'Cancelar',
         accept: () => {
-          this.toastr.info('Procesando su solicitud...', 'Eliminando imagen');
+          this.toastr.info('Procesando su solicitud...', 'Eliminando imagen', this.toastOptions);
 
           // Llamar al servicio para eliminar el adjunto
           this.adjuntoService.eliminarAdjuntoCompleto(idAdjunto).subscribe({
             next: (respuesta) => {
               // Si la eliminación fue exitosa
               if (respuesta) {
-                this.toastr.success(`Imagen ${tipoImagen} eliminada correctamente`, 'Éxito');
+                this.toastr.success(`Imagen ${tipoImagen} eliminada correctamente`, 'Éxito', this.toastOptions);
 
                 // Limpiar la vista previa y el ID según el tipo
                 switch (tipo) {
@@ -590,20 +602,20 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
                     break;
                 }
               } else {
-                this.toastr.error(`No se pudo eliminar la imagen ${tipoImagen}`, 'Error');
+                this.toastr.error(`No se pudo eliminar la imagen ${tipoImagen}`, 'Error', this.toastOptions);
               }
             },
             error: (error) => {
               console.error('Error al eliminar el adjunto:', error);
 
               if (error.status === 400) {
-                this.toastr.error(`No se puede eliminar esta imagen. Verifique que no esté en uso`, 'Error');
+                this.toastr.error(`No se puede eliminar esta imagen. Verifique que no esté en uso`, 'Error', this.toastOptions);
               } else if (error.status === 401 || error.status === 403) {
-                this.toastr.error('No tiene permisos para realizar esta acción', 'Error de autorización');
+                this.toastr.error('No tiene permisos para realizar esta acción', 'Error de autorización', this.toastOptions);
               } else if (error.status === 404) {
-                this.toastr.error('No se encontró la imagen especificada', 'Error');
+                this.toastr.error('No se encontró la imagen especificada', 'Error', this.toastOptions);
               } else {
-                this.toastr.error(`Error al eliminar la imagen ${tipoImagen}: ` + (error.error?.mensaje || error.message), 'Error');
+                this.toastr.error(`Error al eliminar la imagen ${tipoImagen}: ` + (error.error?.mensaje || error.message), 'Error', this.toastOptions);
               }
             }
           });
@@ -709,7 +721,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
       }
 
       if (this.imagenesSubidas > 0) {
-        this.toastr.success(`Se subieron ${this.imagenesSubidas} imágenes nuevas exitosamente`, 'Éxito');
+        this.toastr.success(`Se subieron ${this.imagenesSubidas} imágenes nuevas exitosamente`, 'Éxito', this.toastOptions);
       }
 
       this.cargandoImagenes = false;
@@ -719,10 +731,10 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
       this.cargandoImagenes = false;
 
       if (this.imagenesSubidas > 0) {
-        this.toastr.warning(`Se subieron ${this.imagenesSubidas} de ${this.totalImagenes} imágenes nuevas`, 'Advertencia');
+        this.toastr.warning(`Se subieron ${this.imagenesSubidas} de ${this.totalImagenes} imágenes nuevas`, 'Advertencia', this.toastOptions);
         return true; // Consideramos éxito parcial
       } else {
-        this.toastr.error('No se pudieron subir las imágenes nuevas', 'Error');
+        this.toastr.error('No se pudieron subir las imágenes nuevas', 'Error', this.toastOptions);
         return false;
       }
     }
@@ -737,7 +749,7 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
       },
       error: (error) => {
         console.error('Error al cargar los tipos de vehículo:', error);
-        this.toastr.error('No se pudieron cargar los tipos de vehículo', 'Error');
+        this.toastr.error('No se pudieron cargar los tipos de vehículo', 'Error', this.toastOptions);
       }
     });
   }
@@ -822,12 +834,12 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
             });
 
             // Informar al usuario
-            this.toastr.info(`Se han encontrado ${adjuntos.length} imágenes del vehículo`, 'Imágenes cargadas');
+          this.toastr.info(`Se han encontrado ${adjuntos.length} imágenes del vehículo`, 'Imágenes cargadas', this.toastOptions);
           }
         },
         error: (error) => {
           console.error('Error al obtener adjuntos del vehículo:', error);
-          this.toastr.warning('No se pudieron cargar las imágenes del vehículo', 'Advertencia');
+          this.toastr.warning('No se pudieron cargar las imágenes del vehículo', 'Advertencia', this.toastOptions);
         }
       });
   }
@@ -891,28 +903,35 @@ export class AgregarOrdenTrabajoMecanicoComponent implements OnInit {
         this.ordenData.idVehiculo = 0;
 
         // Notificar al usuario
-        this.toastr.info('Se ha retirado el vehículo', 'Información');
+        this.toastr.info('Se ha retirado el vehículo', 'Información', this.toastOptions);
       }
     });
   }
   crearNuevoPropietario() {
-    this.mostrarDialogRegistroCliente = true;
+    this.registroCliente.mostrarDialogo();
   }
 
   onClienteRegistrado(evento: { documento: string, cliente: any }) {
+    this.toastr.success('Cliente registrado correctamente', 'Éxito', this.toastOptions);
     this.documento = evento.documento;
+    this.registroCliente.cerrarDialogo();
 
-    // Dar un delay para que el backend procese el registro
     setTimeout(() => {
       this.validarCliente();
     }, 500);
   }
 
   onCerrarDialogCliente() {
-    this.mostrarDialogRegistroCliente = false;
+    this.registroCliente.cerrarDialogo();
   }
+
   onVehiculoRegistrado(placa: string) {
+    this.toastr.success('Vehículo registrado correctamente', 'Éxito', this.toastOptions);
     this.placa = placa;
-    this.validarVehiculo();
+    this.registroVehiculo.cerrarDialogo();
+
+    setTimeout(() => {
+      this.validarVehiculo();
+    }, 500);
   }
 }

--- a/src/app/views/shared/components/registro-cliente/registro-cliente.component.html
+++ b/src/app/views/shared/components/registro-cliente/registro-cliente.component.html
@@ -70,145 +70,96 @@
       </div>
     </div>
     
-    <!-- Pestañas del formulario -->
-    <p-tabView [(activeIndex)]="activeTabIndex" 
-           class="form-tabs card-style"
-           [scrollable]="false">
-      <!-- Pestaña de Información Básica -->
-      <p-tabPanel header="Información Básica" [disabled]="cargando">
+    <!-- Stepper del formulario -->
+    <p-stepper [(value)]="activeStep" [linear]="true" class="form-stepper">
+      <!-- Paso Información Básica -->
+      <p-step-panel header="Información Básica">
         <div class="form-section" *ngIf="mostrarCamposPersonaNatural">
-          <!-- ✅ Para persona natural -->
-            <div class="form-field">
-            <label class="form-label required" for="documentoPN">
-                Número de {{ tipoDocumento === 'cedula' ? 'cédula' : 'pasaporte' }}
-            </label>
-            <input pInputText 
-                    id="documentoPN" 
-                    type="text" 
-                    [(ngModel)]="datosPersonaNatural.documento" 
-                    name="documentoPN" 
-                    [placeholder]="tipoDocumento === 'cedula' ? 'Ingrese 10 dígitos' : 'Ingrese 6-12 caracteres'"
-                    [maxlength]="tipoDocumento === 'cedula' ? 10 : 12"
-                    (input)="soloNumeros($event, tipoDocumento)"
-                    (blur)="validarCampo('persona', 'documento', datosPersonaNatural.documento)">
-            <small class="form-hint">
-                {{ tipoDocumento === 'cedula' ? 'Solo números, exactamente 10 dígitos' : 'Letras y números, entre 6-12 caracteres' }}
-            </small>
-            </div>
-          
+          <div class="form-field">
+            <label class="form-label required" for="documentoPN">Número de {{ tipoDocumento === 'cedula' ? 'cédula' : 'pasaporte' }}</label>
+            <input pInputText id="documentoPN" type="text" [(ngModel)]="datosPersonaNatural.documento" name="documentoPN"
+                   [placeholder]="tipoDocumento === 'cedula' ? 'Ingrese 10 dígitos' : 'Ingrese 6-12 caracteres'" [maxlength]="tipoDocumento === 'cedula' ? 10 : 12"
+                   (input)="soloNumeros($event, tipoDocumento)" (blur)="validarCampo('persona', 'documento', datosPersonaNatural.documento)">
+            <small class="form-hint">{{ tipoDocumento === 'cedula' ? 'Solo números, exactamente 10 dígitos' : 'Letras y números, entre 6-12 caracteres' }}</small>
+          </div>
+
           <div class="form-row">
             <div class="form-field">
               <label class="form-label required" for="nombres">Nombres</label>
-              <input pInputText id="nombres" type="text" [(ngModel)]="datosPersonaNatural.nombres" 
-                     name="nombres" placeholder="Nombres completos">
+              <input pInputText id="nombres" type="text" [(ngModel)]="datosPersonaNatural.nombres" name="nombres" placeholder="Nombres completos">
             </div>
-            
             <div class="form-field">
               <label class="form-label required" for="apellidos">Apellidos</label>
-              <input pInputText id="apellidos" type="text" [(ngModel)]="datosPersonaNatural.apellidos" 
-                     name="apellidos" placeholder="Apellidos completos">
+              <input pInputText id="apellidos" type="text" [(ngModel)]="datosPersonaNatural.apellidos" name="apellidos" placeholder="Apellidos completos">
             </div>
           </div>
-          
+
           <div class="form-row">
             <div class="form-field">
               <label class="form-label" for="fechaNacimiento">Fecha de nacimiento</label>
-              <p-calendar id="fechaNacimiento" 
-                          [(ngModel)]="datosPersonaNatural.fechaNacimiento" 
-                          [showIcon]="true" 
-                          [monthNavigator]="true" 
-                          [yearNavigator]="true" 
-                          yearRange="1900:2030" 
-                          name="fechaNacimiento"
-                          appendTo="body">
-              </p-calendar>
+              <p-calendar id="fechaNacimiento" [(ngModel)]="datosPersonaNatural.fechaNacimiento" [showIcon]="true" [monthNavigator]="true" [yearNavigator]="true" yearRange="1900:2030" name="fechaNacimiento" appendTo="body"></p-calendar>
             </div>
             <div class="form-field">
-            <label class="form-label" for="genero">Género</label>
-            <p-dropdown 
-                id="genero" 
-                [options]="generos" 
-                [(ngModel)]="datosPersonaNatural.genero" 
-                name="genero" 
-                placeholder="Seleccionar"
-                appendTo="body">
-            </p-dropdown>
+              <label class="form-label" for="genero">Género</label>
+              <p-dropdown id="genero" [options]="generos" [(ngModel)]="datosPersonaNatural.genero" name="genero" placeholder="Seleccionar" appendTo="body"></p-dropdown>
             </div>
           </div>
         </div>
-        
+
         <div class="form-section" *ngIf="mostrarCamposEmpresa">
           <div class="form-field">
-              <label class="form-label required" for="documentoEmpresa">Número de RUC</label>
-                <input pInputText 
-                        id="documentoEmpresa" 
-                        type="text" 
-                        [(ngModel)]="datosEmpresa.documento" 
-                        name="documentoEmpresa" 
-                        placeholder="Ingrese 13 dígitos"
-                        maxlength="13"
-                        (input)="soloNumeros($event, 'ruc')"
-                        (blur)="validarCampo('empresa', 'documento', datosEmpresa.documento)">
-                <small class="form-hint">Solo números, exactamente 13 dígitos</small>
+            <label class="form-label required" for="documentoEmpresa">Número de RUC</label>
+            <input pInputText id="documentoEmpresa" type="text" [(ngModel)]="datosEmpresa.documento" name="documentoEmpresa" placeholder="Ingrese 13 dígitos" maxlength="13" (input)="soloNumeros($event, 'ruc')" (blur)="validarCampo('empresa', 'documento', datosEmpresa.documento)">
+            <small class="form-hint">Solo números, exactamente 13 dígitos</small>
           </div>
-          
-          
+
           <div class="form-row">
             <div class="form-field">
               <label class="form-label required" for="nombreEmpresa">Nombre comercial</label>
-              <input pInputText id="nombreEmpresa" type="text" [(ngModel)]="datosEmpresa.nombre" 
-                     name="nombreEmpresa" placeholder="Nombre comercial">
+              <input pInputText id="nombreEmpresa" type="text" [(ngModel)]="datosEmpresa.nombre" name="nombreEmpresa" placeholder="Nombre comercial">
             </div>
-            
             <div class="form-field">
               <label class="form-label required" for="razonSocial">Razón social</label>
-              <input pInputText id="razonSocial" type="text" [(ngModel)]="datosEmpresa.razonSocial" 
-                     name="razonSocial" placeholder="Razón social completa">
+              <input pInputText id="razonSocial" type="text" [(ngModel)]="datosEmpresa.razonSocial" name="razonSocial" placeholder="Razón social completa">
             </div>
           </div>
-          
+
           <div class="form-field">
             <label class="form-label required" for="representanteLegal">Representante legal</label>
-            <input pInputText id="representanteLegal" type="text" [(ngModel)]="datosEmpresa.representanteLegal" 
-                   name="representanteLegal" placeholder="Nombre completo del representante">
+            <input pInputText id="representanteLegal" type="text" [(ngModel)]="datosEmpresa.representanteLegal" name="representanteLegal" placeholder="Nombre completo del representante">
           </div>
         </div>
-      </p-tabPanel>
-      
-      <!-- Pestaña de Contacto -->
-      <p-tabPanel header="Datos de Contacto" [disabled]="cargando">
+
+        <div class="stepper-nav">
+          <button pButton type="button" label="Siguiente" (click)="nextStep()" [disabled]="!isStep1Complete()"></button>
+        </div>
+      </p-step-panel>
+
+      <!-- Paso Datos de Contacto -->
+      <p-step-panel header="Datos de Contacto">
         <div class="form-section" *ngIf="mostrarCamposPersonaNatural">
           <div class="form-row">
             <div class="form-field">
               <label class="form-label required" for="email">Email</label>
-              <input pInputText id="email" type="email" [(ngModel)]="datosPersonaNatural.email" 
-                     name="email" placeholder="correo@ejemplo.com"
-                     (blur)="validarCampo('persona', 'email', datosPersonaNatural.email)">
+              <input pInputText id="email" type="email" [(ngModel)]="datosPersonaNatural.email" name="email" placeholder="correo@ejemplo.com" (blur)="validarCampo('persona', 'email', datosPersonaNatural.email)">
             </div>
-            
             <div class="form-field">
               <label class="form-label" for="celular">Celular</label>
-              <input pInputText id="celular" type="tel" [(ngModel)]="datosPersonaNatural.celular" 
-                     name="celular" placeholder="+099 000 0000"
-                     (blur)="validarCampo('persona', 'celular', datosPersonaNatural.celular)">
+              <input pInputText id="celular" type="tel" [(ngModel)]="datosPersonaNatural.celular" name="celular" placeholder="+099 000 0000" (blur)="validarCampo('persona', 'celular', datosPersonaNatural.celular)">
             </div>
           </div>
-          
+
           <div class="form-row">
             <div class="form-field">
               <label class="form-label" for="telefono">Teléfono</label>
-              <input pInputText id="telefono" type="tel" [(ngModel)]="datosPersonaNatural.telefono" 
-                     name="telefono" placeholder="02 000 0000"
-                     (blur)="validarCampo('persona', 'telefono', datosPersonaNatural.telefono)">
+              <input pInputText id="telefono" type="tel" [(ngModel)]="datosPersonaNatural.telefono" name="telefono" placeholder="02 000 0000" (blur)="validarCampo('persona', 'telefono', datosPersonaNatural.telefono)">
             </div>
-            
             <div class="form-field">
               <label class="form-label required" for="direccion">Dirección</label>
-              <input pInputText id="direccion" type="text" [(ngModel)]="datosPersonaNatural.direccion" 
-                     name="direccion" placeholder="Dirección completa">
+              <input pInputText id="direccion" type="text" [(ngModel)]="datosPersonaNatural.direccion" name="direccion" placeholder="Dirección completa">
             </div>
           </div>
-          
+
           <div class="form-field">
             <label class="form-label">Es Local</label>
             <div class="selection-options">
@@ -229,39 +180,30 @@
             </div>
           </div>
         </div>
-        
+
         <div class="form-section" *ngIf="mostrarCamposEmpresa">
           <div class="form-row">
             <div class="form-field">
               <label class="form-label required" for="emailEmpresa">Email</label>
-              <input pInputText id="emailEmpresa" type="email" [(ngModel)]="datosEmpresa.email" 
-                     name="emailEmpresa" placeholder="empresa@ejemplo.com"
-                     (blur)="validarCampo('empresa', 'email', datosEmpresa.email)">
+              <input pInputText id="emailEmpresa" type="email" [(ngModel)]="datosEmpresa.email" name="emailEmpresa" placeholder="empresa@ejemplo.com" (blur)="validarCampo('empresa', 'email', datosEmpresa.email)">
             </div>
-            
             <div class="form-field">
               <label class="form-label" for="celularEmpresa">Celular</label>
-              <input pInputText id="celularEmpresa" type="tel" [(ngModel)]="datosEmpresa.celular" 
-                     name="celularEmpresa" placeholder="+593 00 000 0000"
-                     (blur)="validarCampo('empresa', 'celular', datosEmpresa.celular)">
+              <input pInputText id="celularEmpresa" type="tel" [(ngModel)]="datosEmpresa.celular" name="celularEmpresa" placeholder="+593 00 000 0000" (blur)="validarCampo('empresa', 'celular', datosEmpresa.celular)">
             </div>
           </div>
-          
+
           <div class="form-row">
             <div class="form-field">
               <label class="form-label" for="telefonoEmpresa">Teléfono</label>
-              <input pInputText id="telefonoEmpresa" type="tel" [(ngModel)]="datosEmpresa.telefono" 
-                     name="telefonoEmpresa" placeholder="02 000 0000"
-                     (blur)="validarCampo('empresa', 'telefono', datosEmpresa.telefono)">
+              <input pInputText id="telefonoEmpresa" type="tel" [(ngModel)]="datosEmpresa.telefono" name="telefonoEmpresa" placeholder="02 000 0000" (blur)="validarCampo('empresa', 'telefono', datosEmpresa.telefono)">
             </div>
-            
             <div class="form-field">
               <label class="form-label required" for="direccionEmpresa">Dirección</label>
-              <input pInputText id="direccionEmpresa" type="text" [(ngModel)]="datosEmpresa.direccion" 
-                     name="direccionEmpresa" placeholder="Dirección completa">
+              <input pInputText id="direccionEmpresa" type="text" [(ngModel)]="datosEmpresa.direccion" name="direccionEmpresa" placeholder="Dirección completa">
             </div>
           </div>
-          
+
           <div class="form-field">
             <label class="form-label">Es Local</label>
             <div class="selection-options">
@@ -282,11 +224,20 @@
             </div>
           </div>
         </div>
-      </p-tabPanel>
-      
-      <!-- Pestaña adicional solo para empresas -->
-      <p-tabPanel header="Información Adicional" [disabled]="cargando || isPersonaNatural">
-        <div class="form-section" *ngIf="mostrarCamposEmpresa">
+
+        <div class="stepper-nav" *ngIf="isPersonaNatural">
+          <button pButton type="button" label="Atrás" class="p-button-text" (click)="prevStep()"></button>
+          <button pButton type="button" label="Registrar" (click)="registrarCliente()" [disabled]="cargando || !isStep2Complete()"></button>
+        </div>
+        <div class="stepper-nav" *ngIf="!isPersonaNatural">
+          <button pButton type="button" label="Atrás" class="p-button-text" (click)="prevStep()"></button>
+          <button pButton type="button" label="Siguiente" (click)="nextStep()" [disabled]="!isStep2Complete()"></button>
+        </div>
+      </p-step-panel>
+
+      <!-- Paso Información Adicional para empresas -->
+      <p-step-panel header="Información Adicional" *ngIf="!isPersonaNatural">
+        <div class="form-section">
           <div class="form-field">
             <label class="form-label">Obligada a llevar contabilidad</label>
             <div class="selection-options">
@@ -307,19 +258,16 @@
             </div>
           </div>
         </div>
-      </p-tabPanel>
-    </p-tabView>
+        <div class="stepper-nav">
+          <button pButton type="button" label="Atrás" class="p-button-text" (click)="prevStep()"></button>
+          <button pButton type="button" label="Registrar" (click)="registrarCliente()" [disabled]="cargando || !isStep2Complete()"></button>
+        </div>
+      </p-step-panel>
+    </p-stepper>
   </div>
   
   <!-- Footer del diálogo -->
     <div class="dialog-footer">
-      <button pButton type="button" label="Cancelar" icon="pi pi-times" 
-              class="p-button-text" (click)="cerrarDialogo()"></button>
-      <button pButton type="button" label="Registrar" icon="pi pi-save" 
-              [disabled]="cargando" (click)="registrarCliente()">
-        <span *ngIf="cargando" class="loading-text">
-          <i class="pi pi-spinner pi-spin"></i> Registrando...
-        </span>
-      </button>
+      <button pButton type="button" label="Cancelar" icon="pi pi-times" class="p-button-text" (click)="cerrarDialogo()"></button>
     </div>
 </p-dialog>

--- a/src/app/views/shared/components/registro-cliente/registro-cliente.component.scss
+++ b/src/app/views/shared/components/registro-cliente/registro-cliente.component.scss
@@ -6,6 +6,25 @@
   overflow: hidden !important;
 }
 
+@media (max-width: 575px) {
+  .cliente-dialog {
+    width: 100vw !important;
+    margin: 0 !important;
+  }
+
+  .cliente-dialog .p-dialog-content {
+    max-height: calc(100vh - 80px) !important;
+  }
+
+  .dialog-content {
+    padding: 1rem;
+  }
+
+  .stepper-nav {
+    flex-direction: column;
+  }
+}
+
 .cliente-dialog .p-dialog-header {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
   color: white !important;
@@ -13,6 +32,8 @@
   border-bottom: none !important;
   font-weight: 600 !important;
   font-size: 1.125rem !important;
+  border-top-left-radius: 16px !important;
+  border-top-right-radius: 16px !important;
 }
 
 .cliente-dialog .p-dialog-header .p-dialog-title {
@@ -30,6 +51,9 @@
 .cliente-dialog .p-dialog-content {
   padding: 0 !important;
   background: #f8fafc !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  max-height: calc(90vh - 100px) !important;
 }
 
 /* ===== CONTENIDO DEL DIÁLOGO ===== */
@@ -37,6 +61,18 @@
   padding: 2rem;
   background: #f8fafc;
   min-height: 400px;
+}
+
+/* ===== STEPPER ===== */
+.form-stepper {
+  background: transparent;
+}
+
+.stepper-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.5rem;
 }
 
 /* ===== MENSAJES DE ALERTA ===== */

--- a/src/app/views/shared/components/registro-cliente/registro-cliente.component.ts
+++ b/src/app/views/shared/components/registro-cliente/registro-cliente.component.ts
@@ -6,7 +6,7 @@ import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { ButtonModule } from 'primeng/button';
 import { DropdownModule } from 'primeng/dropdown';
 import { CalendarModule } from 'primeng/calendar';
-import { TabViewModule } from 'primeng/tabview';
+import { StepperModule } from 'primeng/stepper';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { InputTextModule } from 'primeng/inputtext';
 import { DialogModule } from 'primeng/dialog';
@@ -22,7 +22,7 @@ import { CommonModule } from '@angular/common';
     DialogModule,
     InputTextModule,
     RadioButtonModule,
-    TabViewModule,
+    StepperModule,
     CalendarModule,
     DropdownModule,
     ButtonModule
@@ -45,8 +45,8 @@ export class RegistroClienteComponent {
   // Tipo de documento
   tipoDocumento: string = 'cedula';
   
-  // Pestañas activas
-  activeTabIndex: number = 0;
+  // Paso activo del stepper
+  activeStep: number = 0;
   
   // Mensajes
   mensajeExito: string = '';
@@ -112,7 +112,7 @@ export class RegistroClienteComponent {
     this.isPersonaNatural = isPersonaNatural;
     this.mostrarCamposPersonaNatural = isPersonaNatural;
     this.mostrarCamposEmpresa = !isPersonaNatural;
-    this.activeTabIndex = 0;
+    this.activeStep = 0;
     
     // Resetear tipo de documento según el tipo de persona
     this.tipoDocumento = isPersonaNatural ? 'cedula' : 'ruc';
@@ -128,7 +128,7 @@ export class RegistroClienteComponent {
     this.mostrarCamposPersonaNatural = true;
     this.mostrarCamposEmpresa = false;
     this.tipoDocumento = 'cedula';
-    this.activeTabIndex = 0;
+    this.activeStep = 0;
     
     this.datosPersonaNatural = {
       documento: '', 
@@ -158,6 +158,86 @@ export class RegistroClienteComponent {
     
     this.mensajeExito = '';
     this.mensajeError = '';
+  }
+
+  // ======== LÓGICA DEL STEPPER ========
+  nextStep(): void {
+    if (this.activeStep === 0 && this.validarPaso1()) {
+      this.activeStep = 1;
+    } else if (this.activeStep === 1 && !this.isPersonaNatural && this.validarPaso2()) {
+      this.activeStep = 2;
+    }
+  }
+
+  prevStep(): void {
+    if (this.activeStep > 0) {
+      this.activeStep--;
+    }
+  }
+
+  isStep1Complete(): boolean {
+    if (this.isPersonaNatural) {
+      return (
+        this.datosPersonaNatural.documento !== '' &&
+        this.datosPersonaNatural.nombres !== '' &&
+        this.datosPersonaNatural.apellidos !== ''
+      );
+    }
+    return (
+      this.datosEmpresa.documento !== '' &&
+      this.datosEmpresa.nombre !== '' &&
+      this.datosEmpresa.razonSocial !== '' &&
+      this.datosEmpresa.representanteLegal !== ''
+    );
+  }
+
+  isStep2Complete(): boolean {
+    if (this.isPersonaNatural) {
+      return (
+        this.datosPersonaNatural.email !== '' &&
+        this.datosPersonaNatural.celular !== '' &&
+        this.datosPersonaNatural.telefono !== '' &&
+        this.datosPersonaNatural.direccion !== ''
+      );
+    }
+    return (
+      this.datosEmpresa.email !== '' &&
+      this.datosEmpresa.celular !== '' &&
+      this.datosEmpresa.telefono !== '' &&
+      this.datosEmpresa.direccion !== ''
+    );
+  }
+
+  private validarPaso1(): boolean {
+    if (this.isPersonaNatural) {
+      if (!this.validarDocumento(this.datosPersonaNatural.documento, this.tipoDocumento)) return false;
+      if (!this.validarNombre(this.datosPersonaNatural.nombres)) return false;
+      if (!this.validarApellidos(this.datosPersonaNatural.apellidos)) return false;
+      if (!this.validarFechaNacimiento(this.datosPersonaNatural.fechaNacimiento)) return false;
+      if (!this.datosPersonaNatural.genero) {
+        this.toastr.warning('El género es obligatorio', 'Campo requerido');
+        return false;
+      }
+    } else {
+      if (!this.validarDocumento(this.datosEmpresa.documento, 'ruc')) return false;
+      if (!this.validarNombre(this.datosEmpresa.nombre)) return false;
+      if (!this.validarRazonSocial(this.datosEmpresa.razonSocial)) return false;
+      if (!this.validarRepresentanteLegal(this.datosEmpresa.representanteLegal)) return false;
+    }
+    return true;
+  }
+
+  private validarPaso2(): boolean {
+    if (this.isPersonaNatural) {
+      return this.validarEmail(this.datosPersonaNatural.email) &&
+             this.validarCelular(this.datosPersonaNatural.celular) &&
+             this.validarTelefono(this.datosPersonaNatural.telefono) &&
+             this.validarDireccion(this.datosPersonaNatural.direccion);
+    }
+    return this.validarEmail(this.datosEmpresa.email) &&
+           this.validarCelular(this.datosEmpresa.celular) &&
+           this.validarTelefono(this.datosEmpresa.telefono) &&
+           this.validarDireccion(this.datosEmpresa.direccion);
   }
 
   // VALIDACIONES DETALLADAS BASADAS EN LA BASE DE DATOS
@@ -842,31 +922,6 @@ private extraerMensajeError(respuesta: any): string {
   
   return 'Respuesta inesperada del servidor';
 }
-  cambiarPestana(index: number) {
-    if (index < this.activeTabIndex || this.validarPestañaActual()) {
-      this.activeTabIndex = index;
-    }
-  }
-
-  validarPestañaActual(): boolean {
-    if (this.activeTabIndex === 0) {
-      if (this.isPersonaNatural) {
-        return this.datosPersonaNatural.documento !== '' && 
-               this.datosPersonaNatural.nombres !== '' && 
-               this.datosPersonaNatural.apellidos !== '';
-      } else {
-        return this.datosEmpresa.documento !== '' && 
-               this.datosEmpresa.nombre !== '' && 
-               this.datosEmpresa.razonSocial !== '' && 
-               this.datosEmpresa.representanteLegal !== '';
-      }
-    } else if (this.activeTabIndex === 1) {
-      return true;
-    }
-    
-    return false;
-  }
-
   // Método para limitar caracteres en tiempo real
   limitarCaracteres(event: any, maxLength: number): void {
     const valor = event.target.value;

--- a/src/app/views/shared/components/registro-vehiculo/registro-vehiculo.component.html
+++ b/src/app/views/shared/components/registro-vehiculo/registro-vehiculo.component.html
@@ -1,6 +1,6 @@
 <p-dialog [(visible)]="visible" [modal]="true" [draggable]="false" [resizable]="false"
-    [style]="{ width: '750px', maxWidth: '95vw' }" styleClass="vehiculo-dialog" [baseZIndex]="1000"
-    [breakpoints]="{ '1199px': '75vw', '575px': '90vw' }" header="Registrar Nuevo Vehículo">
+    [style]="{ width: '750px', maxWidth: '100vw' }" styleClass="vehiculo-dialog" [baseZIndex]="1000"
+    [breakpoints]="{ '1199px': '75vw', '575px': '100vw' }" header="Registrar Nuevo Vehículo">
 
     <div class="dialog-content">
         <!-- Mensajes de alerta -->

--- a/src/app/views/shared/components/registro-vehiculo/registro-vehiculo.component.scss
+++ b/src/app/views/shared/components/registro-vehiculo/registro-vehiculo.component.scss
@@ -14,6 +14,8 @@
   border-bottom: none !important;
   font-weight: 600 !important;
   font-size: 1.125rem !important;
+  border-top-left-radius: 16px !important;
+  border-top-right-radius: 16px !important;
 }
 
 .vehiculo-dialog .p-dialog-header .p-dialog-title {
@@ -32,6 +34,7 @@
   padding: 0 !important;
   background: #f8fafc !important;
   overflow-y: auto !important;
+  overflow-x: hidden !important;
   max-height: calc(90vh - 140px) !important;
 }
 
@@ -185,6 +188,21 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+@media (max-width: 575px) {
+  .vehiculo-dialog {
+    width: 100vw !important;
+    margin: 0 !important;
+  }
+
+  .vehiculo-dialog .p-dialog-content {
+    max-height: calc(100vh - 80px) !important;
+  }
+
+  .dialog-content {
+    padding: 1rem;
+  }
 }
 
 .info-item p {


### PR DESCRIPTION
## Summary
- Streamline add-order dialog with lighter styling and centralized toast configuration
- Show confirmation and automatically close dialogs after registering new client or vehicle
- Apply consistent toast options across validations and image operations
- Add stepper-based flow for client registration with gated steps and mobile-friendly layout
- Polish client and vehicle dialogs for mobile with rounded headers and single vertical scroll

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c46a04637883339de9b0e9112a8d8c