### PR TITLE
Recalcular IVA tras cambios en detalles de compra

### DIFF
--- a/src/app/views/dashboard/adquisicion/agregar-adquisicion/agregar-adquisicion.component.ts
+++ b/src/app/views/dashboard/adquisicion/agregar-adquisicion/agregar-adquisicion.component.ts
@@ -406,24 +406,30 @@ this.compraService.getCompraDetallada(id).subscribe({
       idImpuesto: this.impuestoSeleccionado?.idImpuesto || 4  
     };
     console.log("detalle Im", detalleCompraPeticion)
-    const detalleCompra = {
+    const detalleCompra: any = {
       codigo: this.selectedItem.codigo,
       description: this.selectedItem.nombre + ' - ' + this.selectedItem.descripcion,
-      magnitud: idMagnitudSeleccionada ? 
-        this.magnitudes.find(magnitud => magnitud.idMagnitud === idMagnitudSeleccionada)?.nombre : 
+      magnitud: idMagnitudSeleccionada ?
+        this.magnitudes.find(magnitud => magnitud.idMagnitud === idMagnitudSeleccionada)?.nombre :
         'N/A',
-      cantidad: cantidadOriginal, 
-      cantidadConvertida: cantidadFinal !== cantidadOriginal ? 
+      cantidad: cantidadOriginal,
+      cantidadConvertida: cantidadFinal !== cantidadOriginal ?
         `(${cantidadFinal} ${this.magnitudOrigenItem?.unidad})` : '',
       cantidadBase: cantidadOriginal,
       valorUnitario: valorUnitario,
       subtotal: cantidadOriginal * valorUnitario,
-      idImpuesto: this.impuestoSeleccionado?.idImpuesto || 4  
+      idImpuesto: this.impuestoSeleccionado?.idImpuesto || 4
     };
-    
+
+    if (this.impuestoSeleccionado?.porcentaje !== undefined) {
+      detalleCompra.porcentajeImpuesto = this.impuestoSeleccionado.porcentaje;
+      detalleCompra.impuestoCalculado = detalleCompra.subtotal * (this.impuestoSeleccionado.porcentaje / 100);
+    }
+
     this.detallesCompraPeticion.push(detalleCompraPeticion);
     this.detallesCompra.push(detalleCompra);
-    this.detalleCompraHandler();  
+    this.detalleCompraHandler();
+    this.calcularImpuestosPorDetalle(this.detallesCompra);
     this.fb_detalleAdquisicion.reset();
     this.toastr.success('Detalle agregado correctamente!', 'Éxito');
   }
@@ -437,6 +443,7 @@ this.compraService.getCompraDetallada(id).subscribe({
             this.detallesCompra.splice(index, 1);
             this.detallesCompraPeticion.splice(index, 1);
             this.detalleCompraHandler(); // Recalcular totales
+            this.calcularImpuestosPorDetalle(this.detallesCompra);
           }
           this.toastr.success('Detalle eliminado correctamente', 'Éxito');
         },
@@ -451,6 +458,7 @@ this.compraService.getCompraDetallada(id).subscribe({
         this.detallesCompra.splice(index, 1);
         this.detallesCompraPeticion.splice(index, 1);
         this.detalleCompraHandler();
+        this.calcularImpuestosPorDetalle(this.detallesCompra);
         this.toastr.success('Detalle eliminado correctamente', 'Éxito');
       }
     }
@@ -884,6 +892,7 @@ private recalcularTotalesCompletos() {
       this.fb_adquisicion.get('id_impuesto')?.setValue(this.impuestoSeleccionado.idImpuesto);
     }
     this.detalleCompraHandler();
+    this.calcularImpuestosPorDetalle(this.detallesCompra);
   }
   calcularImpuestosPorDetalle(detalles: any[]) {
   if (!detalles || detalles.length === 0) {


### PR DESCRIPTION
## Summary
- recalcular el IVA automáticamente al agregar nuevos detalles de compra.
- actualizar el impuesto restante tras eliminar detalles o modificar el impuesto seleccionado.

## Testing
- npm run lint *(fails: script not found)*
- npm run build *(fails: falta la dependencia @auth0/angular-jwt)*

------
https://chatgpt.com/codex/tasks/task_e_68cda3bd10788333bd819b09fd9a26c8