### PR TITLE
Reset mechanic selection state before editing tasks

### DIFF
--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.ts
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.ts
@@ -124,7 +124,7 @@ export class OrdenTrabajoMecanicaComponent implements OnInit {
 
   displayModal = false;
   formEstado: number | null = null;
-  formMecanico: any;
+  formMecanico: number | null = null;
   displayMecanicosDialog: boolean = false;
   mecanicosTareaSeleccionada: any[] = [];
   codigoTareaSeleccionada: string = '';
@@ -780,7 +780,8 @@ private cargarMagnitudesCompatibles(item: any) {
     this.GetItemsByTarea(this.selectedTarea.idTareaOt);
     this.getItemsDisponibles();
     this.formEstado = this.selectedTarea.estado;
-    this.formMecanico = [...this.selectedTarea.mecanicos];
+    this.formMecanico = null;
+    this.duracionEstimadaMecanicosDialogEdit = null;
     this.displayModal = true;
   }
 
@@ -1071,10 +1072,15 @@ private cargarMagnitudesCompatibles(item: any) {
     dialogRef.onClose.subscribe((result: { acceso: boolean }) => {
       this.modalActivo = false;
       if (result?.acceso) {
+        if (this.formMecanico === null || this.duracionEstimadaMecanicosDialogEdit === null) {
+          return;
+        }
+
+        const idMecanico = Number(this.formMecanico);
         const peticion = {
           idTareaOt: this.selectedTarea.idTareaOt,
           mecanicos: [{
-            idMecanico: this.formMecanico,
+            idMecanico,
             duracionEstimada: this.duracionEstimadaMecanicosDialogEdit
           }]
         };


### PR DESCRIPTION
## Summary
- reset the mechanic selection and duration fields when opening the edit modal to avoid stale values
- type the mechanic selection model as a numeric identifier and ensure numeric payloads when assigning mechanics

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cdb75e3c7c8333a95b240138a3cdee