### PR TITLE
Add required validation for OT observation field

### DIFF
--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
@@ -323,6 +323,10 @@
         <label class="block font-medium mt-2">Observación *</label>
         <textarea formControlName="observacion" placeholder="Agrega una observación para la OT..." rows="3"
           class="w-full p-2 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"></textarea>
+        <p class="text-sm text-red-500 mt-1"
+          *ngIf="fb_editOt.get('observacion')?.touched && fb_editOt.get('observacion')?.invalid">
+          La observación es obligatoria.
+        </p>
       </div>
     </ng-container>
     <div class="flex justify-end gap-2">

--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.ts
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.ts
@@ -167,7 +167,7 @@ export class OrdenTrabajoMecanicaComponent implements OnInit {
       prioridad: [0, Validators.required],
       supervisor: [null, Validators.required],
       fechaProgramada: [new Date(), Validators.required],
-      observacion: ['']
+      observacion: ['', Validators.required]
     });
   }
 


### PR DESCRIPTION
## Summary
- require an observation value when editing una orden de trabajo
- show validation feedback for the observation textarea en el diálogo de edición

## Testing
- npm run build *(fails: missing dependency @auth0/angular-jwt)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb85bb6748333b2c72f1c8235bd8c