### PR TITLE
Traducir botones del diálogo de edición de OT

### DIFF
--- a/src/app/views/dashboard/orden-trabajo/orden-trabajo.component.html
+++ b/src/app/views/dashboard/orden-trabajo/orden-trabajo.component.html
@@ -243,8 +243,8 @@
             </div>
         </ng-container>
         <div class="flex justify-end gap-2">
-            <p-button label="Cancel" severity="secondary" (click)="visibleEdit = false" />
-            <p-button label="Save" [disabled]="loadingEditDialog" (click)="updateOT()" />
+            <p-button label="Cancelar" severity="secondary" (click)="visibleEdit = false" />
+            <p-button label="Guardar" [disabled]="loadingEditDialog" (click)="updateOT()" />
         </div>
     </form>
 </p-dialog>


### PR DESCRIPTION
## Summary
- actualizar las etiquetas de los botones del diálogo de edición de orden de trabajo a "Cancelar" y "Guardar" para mantener la coherencia con el resto de la interfaz.

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdba19de1483339d9cdc539ebd9428