### PR TITLE
Ajusta panel de selección de repuestos

### DIFF
--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
@@ -500,7 +500,8 @@
             <p-select [options]="repuestosDisponiblesAux" optionLabel="nombre" optionValue="idItem"
               [(ngModel)]="formRepuesto" (onChange)="onItemSelectionChange($event.value)"
               [placeholder]="tipoItemSeleccionado === 'repuesto' ? 'Busca y selecciona un repuesto' : 'Busca y selecciona un insumo'"
-              [filter]="true" [loading]="loadingItems" appendTo="body" filterBy="nombre,codigo" class="w-full">
+              [filter]="true" [loading]="loadingItems" filterBy="nombre,codigo" class="w-full"
+              [panelStyle]="{ minWidth: '16rem', width: 'min(32rem, 90vw)' }" panelStyleClass="otm-repuestos-panel">
               <ng-template let-item pTemplate="item">
                 <div class="flex flex-col px-2 py-2">
                   <span class="font-semibold text-gray-800 text-sm">{{ item.codigo }} - {{ item.nombre }}</span>

--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.scss
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.scss
@@ -516,7 +516,8 @@ p-card {
   // ✅ Mejorar p-select para que sea consistente
   .p-select {
     width: 100%;
-    
+    max-width: 32rem;
+
     .p-select-label {
       width: 100%;
       overflow: hidden;
@@ -527,6 +528,20 @@ p-card {
     
     .p-select-dropdown {
       right: 0.75rem;
+    }
+  }
+
+  .otm-repuestos-panel {
+    max-width: min(32rem, 90vw);
+    width: min(32rem, 90vw);
+    border-radius: 0.75rem;
+    border: 1px solid #d1d5db;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
+
+    .p-select-items-wrapper {
+      max-height: min(24rem, 60vh);
+      overflow-y: auto;
     }
   }
 


### PR DESCRIPTION
## Summary
- actualizo el selector de repuestos para limitar su overlay y aplicar un estilo dedicado
- defino la clase de panel con bordes, sombra y altura desplazable para la lista de opciones
- ajusto el estilo base de p-select en la vista para evitar que el panel se expanda en exceso

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cdbd52e8e4833383e74a3a222e95fd