### PR TITLE
Adjust task dialog layout responsiveness

### DIFF
--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.html
@@ -342,7 +342,9 @@
 
 <!-- Dialog para editar tarea -->
 <!-- Dialog para editar tarea -->
-<p-dialog [(visible)]="displayModal" [modal]="true" [style]="{width: '500px'}">
+<p-dialog [(visible)]="displayModal" [modal]="true"
+  [style]="{ width: 'min(95vw, 1100px)' }"
+  [breakpoints]="{ '1600px': 'min(90vw, 1200px)', '1400px': 'min(92vw, 1100px)', '1024px': '95vw', '768px': '98vw' }">
   <ng-template pTemplate="header">
     <div class="flex items-center justify-between w-full">
       <div class="flex flex-col">
@@ -434,7 +436,7 @@
       </header>
       <p-divider></p-divider>
       <div class="otm-card-content space-y-4">
-        <div class="grid grid-cols-1 md:grid-cols-[1fr_120px_auto] gap-3 items-end">
+        <div class="grid otm-mechanics-grid gap-3 items-end">
           <div>
             <label class="block font-medium mb-2">Selecciona un mecánico</label>
             <p-select [options]="mecanicosDisponiblesAux" [(ngModel)]="formMecanico" optionLabel="nombreCompleto"
@@ -448,7 +450,7 @@
               [min]="1" [useGrouping]="false" suffix=" U">
             </p-inputnumber>
           </div>
-          <div class="flex md:justify-end">
+          <div class="flex otm-mechanics-grid__actions">
             <p-button label="Agregar" icon="pi pi-plus"
               [disabled]="!formMecanico || !duracionEstimadaMecanicosDialogEdit" (click)="agregarMecanicoTarea()"
               class="w-full md:w-auto">

--- a/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.scss
+++ b/src/app/views/dashboard-mecanica/orden-trabajo-mecanica/orden-trabajo-mecanica.component.scss
@@ -204,13 +204,7 @@ p-card {
 .otm-modal-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 1024px) {
-  .otm-modal-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .otm-modal-card {
@@ -279,6 +273,38 @@ p-card {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.otm-mechanics-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 640px) {
+  .otm-mechanics-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 160px);
+  }
+}
+
+@media (min-width: 960px) {
+  .otm-mechanics-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 180px) minmax(0, auto);
+  }
+}
+
+@media (max-width: 380px) {
+  .otm-mechanics-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.otm-mechanics-grid__actions {
+  justify-content: flex-end;
+}
+
+@media (max-width: 767px) {
+  .otm-mechanics-grid__actions {
+    justify-content: flex-start;
+  }
 }
 
 .otm-external-alert {


### PR DESCRIPTION
## Summary
- make the task edit dialog use a responsive width with large-screen breakpoints
- refactor the mechanics section grid to auto-fit and align button actions responsively
- update modal grid styling to auto-fit cards without forcing two columns

## Testing
- `npm start` *(fails: rollup native optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc38ac98c8333acf69dfec87bf528